### PR TITLE
fix error

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -114,6 +114,8 @@ class API:
                         "X-Requested-With": "com.sengled.life2",
                     },
                     websocket_path=self._inception_url.path,
+                    retry_first_connection=True,
+                    keepalive=60,
                 )
 
                 await client.connect()  # Connect the client


### PR DESCRIPTION
This error is occurring because there's been a change in the asyncio_mqtt library's API. The message_retry_set attribute is no longer available in the newer version. This is likely due to a recent update of the asyncio_mqtt package.